### PR TITLE
Pool Creation gets a new context param used at resource creation time

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -1,1 +1,2 @@
+#!/usr/bin/env bash
 go test -run=NONE -bench=. -cpu=4


### PR DESCRIPTION
`NewPool` gets an additional parameter used to initialize the resources created by the pool. This parameter is just passed back to the `resOpen` function, which can use it as it likes. Useful for example if you want to create several connection pools to different servers. Connection resources in each pool are the same type but with different "server location" property